### PR TITLE
parameter handling: allow backward compatible auth parameters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+2.0.4 2019-07-11
+
+No major new feature. Backward compatible authentication parameters.
+This means user_credential, provider, username, password may reside
+in the safeguard section of the configuration.
+
 2.0.3 2019-06-13
 
 No major new feature.

--- a/MANIFEST
+++ b/MANIFEST
@@ -2,5 +2,5 @@ api: 1.2
 type: credentialstore
 name: SPS_safeguard
 description: One Identity Safeguard for Privileged Passwords plugin
-version: 2.0.3
+version: 2.0.4
 entry_point: main.py

--- a/lib/safeguard.py
+++ b/lib/safeguard.py
@@ -107,14 +107,17 @@ class SafeguardClientFactory(object):
 
     @classmethod
     def from_config(cls, config):
-        return SafeguardClientFactory(
+        def compatible_auth_parameter_get(parameter):
+            return config.get('safeguard', parameter) or config.get('safeguard-password-authentication', parameter)
+
+        return cls(
             addresses=config.get('safeguard', 'address').split(','),
             check_host_name=config.getboolean('safeguard', 'check_host_name'),
             ca=config.get('safeguard', 'ca'),
-            credential_source=config.get('safeguard-password-authentication', 'use_credential'),
-            provider=config.get('safeguard-password-authentication', 'provider'),
-            auth_username=config.get('safeguard-password-authentication', 'username'),
-            auth_password=config.get('safeguard-password-authentication', 'password')
+            credential_source=compatible_auth_parameter_get('use_credential'),
+            provider=compatible_auth_parameter_get('provider'),
+            auth_username=compatible_auth_parameter_get('username'),
+            auth_password=compatible_auth_parameter_get('password')
         )
 
 


### PR DESCRIPTION
Signed-off-by: Gyorgy Krajcsovits <gyorgy.krajcsovits@oneidentity.com>